### PR TITLE
Better CI caching

### DIFF
--- a/.github/workflows/clear-cache.yaml
+++ b/.github/workflows/clear-cache.yaml
@@ -1,12 +1,25 @@
-name: Clear CI Nix cache
+name: Clear CI cache
 
 on: [workflow_dispatch]
 jobs:
   clear-nix-cache:
-    name: Example Job
+    name: Clear cache on CI
     runs-on: ubuntu-latest
+    permissions:
+      actions: "write"
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - name: Run `clear-ci-nix-cache`
-        run: make clear-ci-nix-cache
+      - name: Delete all github action caches
+        run: |
+          echo "Clearing ${GITHUB_REPOSITORY} nix cache..."
+          echo
+
+          gh api --paginate -H "Accept: application/vnd.github+json" \
+            "/repos/${GITHUB_REPOSITORY}/actions/caches" \
+            | for ID in `jq '.actions_caches[].id'`; \
+              do echo "Deleting $ID"; \
+                 gh api --method DELETE "/repos/${GITHUB_REPOSITORY}/actions/caches/$ID" | echo; done
+
+          echo
+          echo "all done"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,13 +11,6 @@ on:
       - "develop"
   workflow_dispatch: {}
 
-env:
-  nix_conf: |
-    experimental-features = nix-command flakes ca-derivations
-    substituters = https://cache.iog.io https://cache.zw3rk.com https://cache.nixos.org/ https://nix-community.cachix.org
-    trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= loony-tools:pr9m4BkM/5/eSTZlkQyRt57Jz7OMBxNSUiMC4FkcNfk= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
-    keep-outputs = true
-
 jobs:
   lints:
     name: Build
@@ -28,9 +21,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Nix
-        uses: nixbuild/nix-quick-install-action@v26
-        with:
-          nix_conf: ${{ env.nix_conf }}
+        uses: DeterminateSystems/nix-installer-action@main
 
       - name: Cache Nix
         uses: actions/cache@v3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,18 +9,35 @@ on:
     branches:
       - "master"
       - "develop"
+  workflow_dispatch: {}
+
+env:
+  nix_conf: |
+    experimental-features = nix-command flakes ca-derivations
+    substituters = https://cache.iog.io https://cache.zw3rk.com https://cache.nixos.org/ https://nix-community.cachix.org
+    trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= loony-tools:pr9m4BkM/5/eSTZlkQyRt57Jz7OMBxNSUiMC4FkcNfk= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
+    keep-outputs = true
 
 jobs:
   lints:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
     steps:
       - uses: actions/checkout@v3
+
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-      - name: Run the Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+        uses: nixbuild/nix-quick-install-action@v26
         with:
-          upstream-cache: https://cache.nixos.org
+          nix_conf: ${{ env.nix_conf }}
+
+      - name: Cache Nix
+        uses: actions/cache@v3
+        with:
+          key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
+          restore-keys: nix-${{ runner.os }}-
+          path: /nix
+
       - name: Run `nix flake check`
         run: make ci

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: nixbuild/nix-quick-install-action@v26
 
       - name: Cache Nix
         uses: actions/cache@v3

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,6 @@ test:
 ci:
 	nix flake check --accept-flake-config --extra-experimental-features ca-derivations
 
-.PHONY: clear-ci-nix-cache
-clear-ci-nix-cache:
-	./clear-ci-nix-cache
-
 .PHONY: export
 export:
 	cabal run smart-handles -f optimized


### PR DESCRIPTION
* [x] better caching/build solution
* [x] clean github cache workflow
* [x] ready for review/merge
----
Note:
The GitHub cache action will report restore failure even when the restore was successful. This is caused by tar unable to extract files that are already in the nix store, but the other files are restored. There is no easy way to fix this at the moment, because the GitHub toolkit insist on using a shitty glob implementation, a regex file path filter would be much better. Apart from the misleading report (and that the unneeded nix packages take place in the cache), there seems to be no drawback at the moment.
